### PR TITLE
Add support for functions when calling mocks

### DIFF
--- a/lib/mock-aws.js
+++ b/lib/mock-aws.js
@@ -44,7 +44,12 @@ function applyMocks(client, service) {
   if (!mocks[service]) { return; }
   mocks[service].forEach(function(mock) {
     client.sandbox.stub(client, mock.name, function(params, callback) {
-      return callback(null, mock.data);
+      // check if it is a function or data
+      if (typeof(mock.data) === 'function') {
+        return mock.data(params,callback);
+      } else {
+        return callback(null, mock.data);
+      }
     });
   });
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,18 @@
 {
   "name": "mock-aws",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Easily mock aws-sdk API methods to enable easier testing of applications which use the AWS SDK for JavaScript",
   "main": "./lib/mock-aws.js",
   "scripts": {
     "test": "mocha -R spec --recursive"
   },
   "author": "Anton Osmond <antonosmond@gmail.com>",
+  "contributors": [
+    {
+      "name": "deitch",
+      "url": "https://github.com/deitch"
+    }
+  ],
   "license": "ISC",
   "dependencies": {
     "sinon": "^1.15.4"

--- a/test/aws-spec.js
+++ b/test/aws-spec.js
@@ -1,3 +1,5 @@
+/*jslint node:true */
+/*global describe, it, beforeEach */
 var should = require('should');
 var AWS = require('../lib/mock-aws');
 
@@ -6,32 +8,48 @@ beforeEach(function() {
 });
 
 describe('When a method is mocked', function() {
-  describe('before the service client has been constructed', function() {
-    it('it should return the mock data when called', function(done) {
+  describe('fixed data', function(){
+    describe('before the service client has been constructed', function() {
+      it('it should return the mock data when called', function(done) {
+        AWS.mock('EC2', 'describeTags', 'test');
+        var ec2 = new AWS.EC2();
+        ec2.describeTags({}, function(err, data) {
+          data.should.eql('test');
+          done();
+        });
+      });
+    });
+    describe('after the service client has been constructed', function() {
+      it('it should return the mock data when called', function(done) {
+        var ec2 = new AWS.EC2();
+        AWS.mock('EC2', 'describeTags', 'test');
+        ec2.describeTags({}, function(err, data) {
+          data.should.eql('test');
+          done();
+        });
+      });
+    });
+    it.skip('unmocked methods should work as normal', function(done) {
       AWS.mock('EC2', 'describeTags', 'test');
-      var ec2 = new AWS.EC2();
-      ec2.describeTags({}, function(err, data) {
-        data.should.eql('test');
+      var ec2 = new AWS.EC2({ region: 'us-east-1' });
+      ec2.describeVpcs({}, function(err, data) {
+        data.should.have.property('Vpcs');
         done();
       });
     });
   });
-  describe('after the service client has been constructed', function() {
-    it('it should return the mock data when called', function(done) {
+  describe('functions', function(){
+    it('should return the mock data when called', function(done){
+      var expected;
+      AWS.mock('EC2', 'describeTags', function (options,cb) {
+        expected = Math.floor((Math.random() * 1000) + 1);
+        cb(null,expected);
+      });
       var ec2 = new AWS.EC2();
-      AWS.mock('EC2', 'describeTags', 'test');
       ec2.describeTags({}, function(err, data) {
-        data.should.eql('test');
+        data.should.eql(expected);
         done();
       });
-    });
-  });
-  it.skip('unmocked methods should work as normal', function(done) {
-    AWS.mock('EC2', 'describeTags', 'test');
-    var ec2 = new AWS.EC2({ region: 'us-east-1' });
-    ec2.describeVpcs({}, function(err, data) {
-      data.should.have.property('Vpcs');
-      done();
     });
   });
 });


### PR DESCRIPTION
Instead of just fixed `data` as the third argument to `mock()`, it can be fixed or functions. This gives the ability to look at parameters, provide variable data, send data or call an error.
