### PR TITLE
Supporting AWS mocking calls with three parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Mocks an AWS service method to return the specified test data or a function
 - **method (string):** the service's method to be be mocked e.g. describeTags
 - **data (object):** the test data that the mocked method should return or a function that is called
 
-The parameter `data` can be either fixed data, in which case the original callback will be called with that data, or it can be a function. If it is a function, then when the mocked service is called, your function will be called. 
+The parameter `data` can be either fixed data, in which case the original callback will be called with that data, or it can be a function. If it is a function, then when the mocked service is called, your function will be called.
 
 If it is a function, it will be passed all of the parameters passed to the original AWS SDK call, including the callback. **You are expected to call the callback.**
 
@@ -61,6 +61,35 @@ ec2.describeTags({special: true}, function(err, data) {
   console.log(data); // data should be "special"
 });
 ec2.describeTags({strange:true}, function(err, data) {
+  console.log(err);  // err should be null
+  console.log(data); // data should be "weird"
+});
+```
+
+```js
+var AWS = require('mock-aws');
+var s3 = new AWS.S3();
+
+AWS.mock('S3', 'upload', function(params,options,callback){
+  params = params || {};
+  options = options || {};
+  if (params.special) {
+    callback(null,"special");
+  } else if (options.strange) {
+    callback(null,"weird");
+  } else {
+    callback("ERROR!");
+  }
+});
+s3.upload({}, {}, function(err, data) {
+  console.log(err);  // err should equal "ERROR!"
+  console.log(data); // data should be undefined
+});
+s3.upload({special: true}, {}, function(err, data) {
+  console.log(err);  // err should be null
+  console.log(data); // data should be "special"
+});
+s3.upload({}, {strange:true}, function(err, data) {
   console.log(err);  // err should be null
   console.log(data); // data should be "weird"
 });

--- a/lib/mock-aws.js
+++ b/lib/mock-aws.js
@@ -44,10 +44,13 @@ function applyMocks(client, service) {
   if (!mocks[service]) { return; }
   mocks[service].forEach(function(mock) {
     client.sandbox.stub(client, mock.name, function(params, callback) {
+      var args = Array.prototype.slice.call(arguments);
+
       // check if it is a function or data
       if (typeof(mock.data) === 'function') {
-        return mock.data(params,callback);
+        return mock.data.apply(mock.data, arguments);
       } else {
+        var callback = args[args.length - 1];
         return callback(null, mock.data);
       }
     });

--- a/test/aws-spec.js
+++ b/test/aws-spec.js
@@ -51,6 +51,18 @@ describe('When a method is mocked', function() {
         done();
       });
     });
+    it('should return the mock data when called with three parameters', function(done){
+      var expected;
+      AWS.mock('S3', 'upload', function (params,options,cb) {
+        expected = Math.floor((Math.random() * 1000) + 1);
+        cb(null,expected);
+      });
+      var s3 = new AWS.S3();
+      s3.upload({}, {},  function(err, data) {
+        data.should.eql(expected);
+        done();
+      });
+    });
   });
 });
 


### PR DESCRIPTION
We use some AWS methods with 3 parameters instead of 2. The last parameter is still a callback and otherwise everything else is the same. Thanks for the library.
